### PR TITLE
for in & for of enhance

### DIFF
--- a/src/statement.ts
+++ b/src/statement.ts
@@ -1124,9 +1124,12 @@ export default class StatementProcessor {
             incrementor = initExpr;
         }
 
-        const statement = this.visitNode(forOfStmtNode.statement)!;
+        let statement = this.visitNode(forOfStmtNode.statement)!;
         if (!(statement instanceof BlockStatement)) {
-            throw new UnimplementError('unimpl for of without a block scope');
+            const blockScope = new Scope(scope);
+            blockScope.statements.push(statement);
+            statement = new BlockStatement();
+            statement.setScope(blockScope);
         }
         const scopeStmts = statement.getScope()!.statements;
         if (isStaticExpr) {
@@ -1272,9 +1275,12 @@ export default class StatementProcessor {
         );
         incrementor.setExprType(numberType);
 
-        const statement = this.visitNode(forInStmtNode.statement)!;
+        let statement = this.visitNode(forInStmtNode.statement)!;
         if (!(statement instanceof BlockStatement)) {
-            throw new UnimplementError('unimpl for of without a block scope');
+            const blockScope = new Scope(scope);
+            blockScope.statements.push(statement);
+            statement = new BlockStatement();
+            statement.setScope(blockScope);
         }
         const scopeStmts = statement.getScope()!.statements;
         const elemAccessExpr = new ElementAccessExpression(

--- a/tests/samples/for_of.ts
+++ b/tests/samples/for_of.ts
@@ -11,6 +11,9 @@ export function forOfForArray(): void {
     for (const element of arr) {
         console.log(element);
     }
+
+    for (const element of arr) console.log(element);
+
     const localArr = arr;
     for (const element of localArr) {
         console.log(element);
@@ -18,6 +21,7 @@ export function forOfForArray(): void {
     for (const element of dynArr) {
         console.log(element);
     }
+    for (const element of dynArr) console.log(element);
     const localDynArr = dynArr;
     for (const element of localDynArr) {
         console.log(element);
@@ -38,7 +42,7 @@ map.set('key2', 'value2');
 set.add('value1');
 set.add('value2');
 
-const mapKeys = map.keys();
+let mapKeys = map.keys();
 const mapValue = map.values();
 const mapEntries = map.entries();
 const setValues = set.values();
@@ -47,6 +51,9 @@ export function forOfForMapKeys() {
     for (const element of mapKeys) {
         console.log(element);
     }
+    mapKeys = map.keys();
+    for (const element of mapKeys)
+        console.log(element);
     const localMapKeys = map.keys();
     for (const element of localMapKeys) {
         console.log(element);

--- a/tools/validate/wamr/validation.json
+++ b/tools/validate/wamr/validation.json
@@ -3784,7 +3784,7 @@
             {
                 "name": "forOfForArray",
                 "args": [],
-                "result": "1\n4\n6\n1\n4\n6\n2\n3\n5\n2\n3\n5"
+                "result": "1\n4\n6\n1\n4\n6\n1\n4\n6\n2\n3\n5\n2\n3\n5\n2\n3\n5"
             },
             {
                 "name": "forOfForString",
@@ -3794,7 +3794,7 @@
             {
                 "name": "forOfForMapKeys",
                 "args": [],
-                "result": "key1\nkey2\nkey1\nkey2"
+                "result": "key1\nkey2\nkey1\nkey2\nkey1\nkey2"
             },
             {
                 "name": "forOfForMapValues",


### PR DESCRIPTION
support `for in` and `for of` which without a following block:
```typescript
const obj;
for (const x of obj) console.log(x);
```