### PR TITLE
improvement: optimize the logic of determining whether a file is a standard library

### DIFF
--- a/src/import_resolve.ts
+++ b/src/import_resolve.ts
@@ -35,8 +35,8 @@ export class ImportResolver {
         /* Auto import the standard library module for every user file */
         const builtinScopes = this.globalScopes.filter((scope) => {
             return !!this.parserCtx.builtinFileNames.find((name) => {
-                const fileName = path.basename(scope.moduleName);
-                return name.includes(fileName);
+                // the contents of builtinFileName and debugFilePath of globalScope are both absolute paths
+                return name === scope.debugFilePath;
             });
         });
 

--- a/tests/samples/lib.ts
+++ b/tests/samples/lib.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright (C) 2023 Xiaomi Corporation.  All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ */
+
+export function test() {
+    console.log('hello')
+}

--- a/tools/validate/wamr/validation.json
+++ b/tools/validate/wamr/validation.json
@@ -2845,6 +2845,16 @@
         ]
     },
     {
+        "module": "lib",
+        "entries": [
+            {
+                "name": "test",
+                "args": [],
+                "result": "hello"
+            }
+        ]
+    },
+    {
         "module": "loop_do_while",
         "entries": [
             {


### PR DESCRIPTION
Currently, the file names of the standard library are defined in advance: _**lib.type.d.ts**_ and _**lib_builtin.ts**_. 
If the user-defined file name is included in the absolute path string of the standard library file, then the custom file is considered to be a standard library file.
At this time, if we use the standard library function in the custom file, such as **console.log**, an error that the 'console' definition cannot be found will be reported.